### PR TITLE
Avoid Math.max.apply

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,17 @@ SemVerStore.prototype.empty = function () {
   return this
 }
 
+function getMax (arr) {
+  var l = arr.length
+  var max = arr[0]
+  for (var i = 1; i < l; i++) {
+    if (arr[i] > max) {
+      max = arr[i]
+    }
+  }
+  return max
+}
+
 function Node (prefix, children, store) {
   this.prefix = Number(prefix) || 0
   this.children = children || null
@@ -119,7 +130,7 @@ function Node (prefix, children, store) {
 Node.prototype.getChild = function (prefix) {
   if (this.children === null) return null
   if (prefix === 'x') {
-    var max = Math.max.apply(Math, this.childrenPrefixes)
+    var max = getMax(this.childrenPrefixes)
     return this.children[max]
   }
   return this.children[prefix] || null

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/delvedor/semver-store#readme",
   "devDependencies": {
     "benchmark": "^2.1.4",
+    "pre-commit": "^1.2.2",
     "standard": "^11.0.1",
     "tap": "^12.0.1"
   }


### PR DESCRIPTION
`getChild` is hot code.

```
$ node benchMax.js 
Math.max.apply(Math, arr) x 26,094,752 ops/sec ±3.09% (86 runs sampled)
getMax(arr) x 82,660,189 ops/sec ±5.21% (80 runs sampled)
```

```js
'use strict'

const Benchmark = require('benchmark')
const suite = Benchmark.Suite()

const arr = [1, 5, 2, 7, 3]

function getMax (arr) {
  var l = arr.length
  var max = arr[0]
  for (var i = 1; i < l; i++) {
    if (arr[i] > max) {
      max = arr[i]
    }
  }
  return max
}

suite
  .add('Math.max.apply(Math, arr)', function () {
    Math.max.apply(Math, arr)
  })
  .add('getMax(arr)', function () {
    getMax(arr)
  })
  .on('cycle', function (event) {
    console.log(String(event.target))
  })
  .on('complete', function () {})
  .run()

```